### PR TITLE
배경 음영 제거(+팀 목록 테이블 색과 간격조정)

### DIFF
--- a/app/(general)/performances/[id]/teams/_components/RelatedPerformanceList/ButtonView.tsx
+++ b/app/(general)/performances/[id]/teams/_components/RelatedPerformanceList/ButtonView.tsx
@@ -13,7 +13,7 @@ interface SelectViewProps {
 const ButtonView = ({ currentPerformanceId, performanceOptions }: SelectViewProps) => {
   return (
     <div>
-      <p className="my-8 text-center font-bold">Performances</p>
+      <p className="mb-8 text-center font-bold">Performances</p>
       <div className="flex gap-x-4">
         {performanceOptions.map((p) => (
           <Link key={p.id} href={ROUTES.PERFORMANCE.TEAM.LIST(p.id)}>

--- a/app/(general)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
+++ b/app/(general)/performances/[id]/teams/_components/TeamListTable/data-table.tsx
@@ -294,7 +294,7 @@ export function TeamListDataTable<TValue>({
         </div>
 
         {/* 헤더 */}
-        <div className="flex items-center justify-between py-4">
+        <div className="flex items-center justify-between pt-10">
           {/* 검색 */}
           <Input
             placeholder="검색"
@@ -406,7 +406,7 @@ export function TeamListDataTable<TValue>({
         </div>
 
         {/* 페이지네이션 */}
-        <div className="flex items-center justify-center space-x-2 py-4">
+        <div className="flex items-center justify-center space-x-2 pb-6 pt-14">
           <Button
             variant="outline"
             size="sm"
@@ -447,11 +447,7 @@ export function TeamListDataTable<TValue>({
             {/* 필터 */}
             <Popover>
               <PopoverTrigger>
-                <MobileButton
-                  asChild
-                  variant="outline"
-                  className="py-3 px-2"
-                >
+                <MobileButton asChild variant="outline" className="px-2 py-3">
                   <div>
                     <Filter />
                   </div>
@@ -489,7 +485,9 @@ export function TeamListDataTable<TValue>({
 
             {/* 생성 버튼 */}
             <Button asChild className="h-full rounded-md py-1">
-              <Link href={ROUTES.PERFORMANCE.TEAM.CREATE(DEFAULT_PERFORMANCE_ID)}>
+              <Link
+                href={ROUTES.PERFORMANCE.TEAM.CREATE(DEFAULT_PERFORMANCE_ID)}
+              >
                 <CirclePlus size={22} />
                 &nbsp;Create
               </Link>

--- a/app/(general)/performances/[id]/teams/_components/TeamListTable/table.tsx
+++ b/app/(general)/performances/[id]/teams/_components/TeamListTable/table.tsx
@@ -58,7 +58,7 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      "transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      "border-t-[16px] border-t-neutral-50 transition-colors data-[state=selected]:bg-muted",
       className
     )}
     {...props}
@@ -87,7 +87,10 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn("px-4 py-6 border-y-8 border-white align-middle [&:has([role=checkbox])]:pr-0", className)}
+    className={cn(
+      "border-t-8 border-white bg-white px-4 py-6 align-middle [&:has([role=checkbox])]:pr-0",
+      className
+    )}
     {...props}
   />
 ))

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,10 +35,8 @@ export default function RootLayout({
     <html lang="ko">
       <SessionProvider>
         <body className={cn(fontSans.className, "bg-neutral-50")}>
-          <div className="bg-white">
-            {children}
-            <Toaster />
-          </div>
+          {children}
+          <Toaster />
         </body>
       </SessionProvider>
     </html>


### PR DESCRIPTION
close #124 

![image](https://github.com/user-attachments/assets/2d9f7e0f-92cb-4209-9481-7db1905fb7bd)

 배경에 생기는 음영을 제거하고(배경색은 기본 neutral-50이길래 그걸로 통일했습니다), 팀 목록 테이블의 색과 간격도 조정했습니다.
  
