### PR TITLE
팀 생성 페이지 화면 비율 오류 수정 

### DIFF
--- a/app/(general)/performances/[id]/teams/create/page.tsx
+++ b/app/(general)/performances/[id]/teams/create/page.tsx
@@ -32,7 +32,7 @@ const TeamCreatePage = async ({ params }: TeamCreatePageProps) => {
           <RiArrowGoBackLine className="text-white" />
           뒤로가기
         </Link>
-        
+
         {/* 페이지 제목 */}
         <OleoPageHeader title="Create Your Team" />
 
@@ -40,7 +40,7 @@ const TeamCreatePage = async ({ params }: TeamCreatePageProps) => {
       </div>
 
       {/* 양식 */}
-      <TeamForm className="z-10 w-2/3 bg-white" />
+      <TeamForm className="z-10 bg-white px-7 py-10 md:w-2/3 md:p-20" />
 
       <div className="absolute top-0 z-0 h-80 w-full bg-primary"></div>
     </div>


### PR DESCRIPTION
close #139 

![image](https://github.com/user-attachments/assets/062ee732-79ae-4335-bd6f-75321f8bf921)
위와 같이 원상복구 했습니다.